### PR TITLE
調味料保存時エラー

### DIFF
--- a/app/controllers/seasonings_controller.rb
+++ b/app/controllers/seasonings_controller.rb
@@ -7,23 +7,28 @@ class SeasoningsController < ApplicationController
 
   def new
     @seasoning = Seasoning.new
-    @user_seasoning = @seasoning.user_seasonings.build
+    # @user_seasoning = @seasoning.user_seasonings.build
     # @user = current_user
+    # @seasoning = Seasoning.find(params[:seasoning_id])
+    # @user_seasoning = UserSeasoning.new
   end
 
   def create
     # binding.pry
-    
+    @seasoning = Seasoning.new(seasoning_params)
+    # @seasoning.user_id = current_user.id
+    # @seasoning = Seasoning.find(params[:seasoning_id])
+    # @user_seasoning = UserSeasoning.new(seasoning_params)
     # @user_seasoning = UserSeasoning.includes(:seasonings).where(user_id: current_user.id)
     # @user_seasoning = Seasoning.includes(:user).where(user_id: current_user.id)
-    @user_seasoning = Seasoning.includes(:user_seasonings).where(user_id: current_user.id)
+    # @user_seasoning = Seasoning.includes(:user_seasonings).where(user_id: current_user.id)
     # @seasoning = Seasoning.includes(user_id: current_user.id).create(seasoning_params)
     # @seasoning = @user_seasoning.build(seasoning_params)
     # @user = current_user
     # @user_seasoning = @user.seasonings.build(seasoning_params)
     # @user = User.find(params[:user_id])
     # @seasoning = @user.seasonings.create(seasoning_params)
-    @seasoning = @user_seasoning.create(seasoning_params)
+    # @seasoning = @user_seasoning.create(seasoning_params)
     if @seasoning.save
       # binding.pry
       redirect_to action: :index
@@ -35,7 +40,7 @@ class SeasoningsController < ApplicationController
   private
   
   def seasoning_params
-    params.require(:seasoning).permit(:name, :user_created_at, :created_at, :updated_at, user_ids: [], user_seasonings_attributes: [seasoning_ids: []], seasonings: {}).merge(user_id: current_user.id)
+    params.require(:seasoning).permit(:name, :user_created_at, :created_at, :updated_at, :user_id, user_ids: [], seasoning_ids: [], seasonings: {}).merge(user_id: current_user.id)
   end
 
 end

--- a/app/controllers/seasonings_controller.rb
+++ b/app/controllers/seasonings_controller.rb
@@ -7,6 +7,7 @@ class SeasoningsController < ApplicationController
 
   def new
     @seasoning = Seasoning.new
+    @user = User.find(current_user.id) 
     # @user_seasoning = @seasoning.user_seasonings.build
     # @user = current_user
     # @seasoning = Seasoning.find(params[:seasoning_id])
@@ -15,7 +16,19 @@ class SeasoningsController < ApplicationController
 
   def create
     # binding.pry
-    @seasoning = Seasoning.new(seasoning_params)
+    @user_seasonings = [] 
+    if seasoning_params[:seasonings][:name].present?
+      s = Seasoning.create(name: seasoning_params[:seasonings][:name])
+    
+      @user_seasonings << UserSeasoning.new(seasoning_id: s.id, user_id: seasoning_params[:user_id])
+    
+    end
+    
+    seasoning_params[:seasonings][:seasoning_ids].each do |sid|
+    @user_seasonings << UserSeasoning.new(seasoning_id: sid, user_id: seasoning_params[:user_id])
+    end
+    
+    # @seasoning = Seasoning.create(seasoning_params)
     # @seasoning.user_id = current_user.id
     # @seasoning = Seasoning.find(params[:seasoning_id])
     # @user_seasoning = UserSeasoning.new(seasoning_params)
@@ -29,8 +42,10 @@ class SeasoningsController < ApplicationController
     # @user = User.find(params[:user_id])
     # @seasoning = @user.seasonings.create(seasoning_params)
     # @seasoning = @user_seasoning.create(seasoning_params)
-    if @seasoning.save
-      # binding.pry
+    if @user_seasonings.map(&:valid?).all?      
+      @user_seasonings.each do |us|
+        us.save
+      end
       redirect_to action: :index
     else
       render :new

--- a/app/controllers/seasonings_controller.rb
+++ b/app/controllers/seasonings_controller.rb
@@ -7,15 +7,25 @@ class SeasoningsController < ApplicationController
 
   def new
     @seasoning = Seasoning.new
-    # @user = current_user.id
-    # @seasoning.user_seasonings.build
+    @user_seasoning = @seasoning.user_seasonings.build
+    # @user = current_user
   end
 
   def create
     # binding.pry
-    @seasoning = Seasoning.create(seasoning_params)
-    # @seasoning = current_user.seasonings.build(seasoning_params)
+    
+    # @user_seasoning = UserSeasoning.includes(:seasonings).where(user_id: current_user.id)
+    # @user_seasoning = Seasoning.includes(:user).where(user_id: current_user.id)
+    @user_seasoning = Seasoning.includes(:user_seasonings).where(user_id: current_user.id)
+    # @seasoning = Seasoning.includes(user_id: current_user.id).create(seasoning_params)
+    # @seasoning = @user_seasoning.build(seasoning_params)
+    # @user = current_user
+    # @user_seasoning = @user.seasonings.build(seasoning_params)
+    # @user = User.find(params[:user_id])
+    # @seasoning = @user.seasonings.create(seasoning_params)
+    @seasoning = @user_seasoning.create(seasoning_params)
     if @seasoning.save
+      # binding.pry
       redirect_to action: :index
     else
       render :new
@@ -25,7 +35,7 @@ class SeasoningsController < ApplicationController
   private
   
   def seasoning_params
-    params.require(:seasoning).permit(:name, :user_created_at, :created_at, :updated_at, seasoning_ids: [], user_ids: [], user_seasonings_ids: [], user_seasonings_attributes:[:id,:seasoning_id, :user_id]).merge(user_id: current_user.id)
+    params.require(:seasoning).permit(:name, :user_created_at, :created_at, :updated_at, user_ids: [], user_seasonings_attributes: [seasoning_ids: []], seasonings: {}).merge(user_id: current_user.id)
   end
 
 end

--- a/app/controllers/seasonings_controller.rb
+++ b/app/controllers/seasonings_controller.rb
@@ -7,55 +7,61 @@ class SeasoningsController < ApplicationController
 
   def new
     @seasoning = Seasoning.new
-    @user = User.find(current_user.id) 
     # @user_seasoning = @seasoning.user_seasonings.build
-    # @user = current_user
-    # @seasoning = Seasoning.find(params[:seasoning_id])
-    # @user_seasoning = UserSeasoning.new
   end
 
   def create
-    # binding.pry
-    @user_seasonings = [] 
-    if seasoning_params[:seasonings][:name].present?
-      s = Seasoning.create(name: seasoning_params[:seasonings][:name])
+    binding.pry
+    # @user_seasonings = UserSeasoning.new
+    # seasoning = Seasoning.create(seasoning_params)
+    # @seasoning = @user_seasonings.build_seasoning(seasoning_params)
+    # @seasoning = @user_seasonings.seasonings.build(seasoning_params)
     
-      @user_seasonings << UserSeasoning.new(seasoning_id: s.id, user_id: seasoning_params[:user_id])
+    # @user_seasonings = seasoning.user_seasonings.build(seasoning_params)
     
-    end
-    
-    seasoning_params[:seasonings][:seasoning_ids].each do |sid|
-    @user_seasonings << UserSeasoning.new(seasoning_id: sid, user_id: seasoning_params[:user_id])
-    end
-    
-    # @seasoning = Seasoning.create(seasoning_params)
-    # @seasoning.user_id = current_user.id
-    # @seasoning = Seasoning.find(params[:seasoning_id])
-    # @user_seasoning = UserSeasoning.new(seasoning_params)
-    # @user_seasoning = UserSeasoning.includes(:seasonings).where(user_id: current_user.id)
-    # @user_seasoning = Seasoning.includes(:user).where(user_id: current_user.id)
-    # @user_seasoning = Seasoning.includes(:user_seasonings).where(user_id: current_user.id)
-    # @seasoning = Seasoning.includes(user_id: current_user.id).create(seasoning_params)
-    # @seasoning = @user_seasoning.build(seasoning_params)
     # @user = current_user
-    # @user_seasoning = @user.seasonings.build(seasoning_params)
-    # @user = User.find(params[:user_id])
-    # @seasoning = @user.seasonings.create(seasoning_params)
-    # @seasoning = @user_seasoning.create(seasoning_params)
-    if @user_seasonings.map(&:valid?).all?      
-      @user_seasonings.each do |us|
-        us.save
-      end
+    # @seasoning = @user.seasonings.build(seasoning_params)
+    
+    # user_seasonings = UserSeasoning.new
+    # @seasoning = Seasonig.new
+    @seasoning = Seasonig.find_or_created_by(seasoning_params)
+    @user_seasonings = @seasoning.user_seasonings.build({user_id: current_user.id}, {seasoning_id: @seasoning.id})
+    # @user_seasonings = UserSeasoning.build({user_id: current_user.id}, {seasoning_id: @seasoning.id})
+    
+    if @user_seasonings.save
       redirect_to action: :index
     else
       render :new
     end
   end
 
+
+
+
+  #   @user_seasonings = [] 
+  #   if seasoning_params[:seasonings][:name].present?
+  #     s = Seasoning.find_or_created_by(name: seasoning_params[:seasonings][:name])
+  #     @user_seasonings << UserSeasoning.new(seasoning_id: s.id, user_id: seasoning_params[:user_id])
+  #   end
+    
+  #   seasoning_params[:seasonings][:seasoning_ids].each do |sid|
+  #     @user_seasonings << UserSeasoning.new(seasoning_id: sid, user_id: seasoning_params[:user_id])
+  #   end
+    
+  #   if @user_seasonings.map(&:valid?).all?      
+  #     @user_seasonings.each do |us|
+  #       us.save
+  #     end
+  #     redirect_to action: :index
+  #   else
+  #     render :new
+  #   end
+  # end
+
   private
   
   def seasoning_params
-    params.require(:seasoning).permit(:name, :user_created_at, :created_at, :updated_at, :user_id, user_ids: [], seasoning_ids: [], seasonings: {}).merge(user_id: current_user.id)
+    params.require(:seasoning).permit(:name, :user_created_at, :created_at, :updated_at, :user_id, user_ids: [], :seasoning_id, seasoning_ids: [], seasonings: {}).merge(user_id: current_user.id)
   end
 
 end

--- a/app/controllers/seasonings_controller.rb
+++ b/app/controllers/seasonings_controller.rb
@@ -7,61 +7,55 @@ class SeasoningsController < ApplicationController
 
   def new
     @seasoning = Seasoning.new
+    @user = User.find(current_user.id) 
     # @user_seasoning = @seasoning.user_seasonings.build
+    # @user = current_user
+    # @seasoning = Seasoning.find(params[:seasoning_id])
+    # @user_seasoning = UserSeasoning.new
   end
 
   def create
-    binding.pry
-    # @user_seasonings = UserSeasoning.new
-    # seasoning = Seasoning.create(seasoning_params)
-    # @seasoning = @user_seasonings.build_seasoning(seasoning_params)
-    # @seasoning = @user_seasonings.seasonings.build(seasoning_params)
+    # binding.pry
+    @user_seasonings = [] 
+    if seasoning_params[:seasonings][:name].present?
+      s = Seasoning.create(name: seasoning_params[:seasonings][:name])
     
-    # @user_seasonings = seasoning.user_seasonings.build(seasoning_params)
+      @user_seasonings << UserSeasoning.new(seasoning_id: s.id, user_id: seasoning_params[:user_id])
     
+    end
+    
+    seasoning_params[:seasonings][:seasoning_ids].each do |sid|
+    @user_seasonings << UserSeasoning.new(seasoning_id: sid, user_id: seasoning_params[:user_id])
+    end
+    
+    # @seasoning = Seasoning.create(seasoning_params)
+    # @seasoning.user_id = current_user.id
+    # @seasoning = Seasoning.find(params[:seasoning_id])
+    # @user_seasoning = UserSeasoning.new(seasoning_params)
+    # @user_seasoning = UserSeasoning.includes(:seasonings).where(user_id: current_user.id)
+    # @user_seasoning = Seasoning.includes(:user).where(user_id: current_user.id)
+    # @user_seasoning = Seasoning.includes(:user_seasonings).where(user_id: current_user.id)
+    # @seasoning = Seasoning.includes(user_id: current_user.id).create(seasoning_params)
+    # @seasoning = @user_seasoning.build(seasoning_params)
     # @user = current_user
-    # @seasoning = @user.seasonings.build(seasoning_params)
-    
-    # user_seasonings = UserSeasoning.new
-    # @seasoning = Seasonig.new
-    @seasoning = Seasonig.find_or_created_by(seasoning_params)
-    @user_seasonings = @seasoning.user_seasonings.build({user_id: current_user.id}, {seasoning_id: @seasoning.id})
-    # @user_seasonings = UserSeasoning.build({user_id: current_user.id}, {seasoning_id: @seasoning.id})
-    
-    if @user_seasonings.save
+    # @user_seasoning = @user.seasonings.build(seasoning_params)
+    # @user = User.find(params[:user_id])
+    # @seasoning = @user.seasonings.create(seasoning_params)
+    # @seasoning = @user_seasoning.create(seasoning_params)
+    if @user_seasonings.map(&:valid?).all?      
+      @user_seasonings.each do |us|
+        us.save
+      end
       redirect_to action: :index
     else
       render :new
     end
   end
 
-
-
-
-  #   @user_seasonings = [] 
-  #   if seasoning_params[:seasonings][:name].present?
-  #     s = Seasoning.find_or_created_by(name: seasoning_params[:seasonings][:name])
-  #     @user_seasonings << UserSeasoning.new(seasoning_id: s.id, user_id: seasoning_params[:user_id])
-  #   end
-    
-  #   seasoning_params[:seasonings][:seasoning_ids].each do |sid|
-  #     @user_seasonings << UserSeasoning.new(seasoning_id: sid, user_id: seasoning_params[:user_id])
-  #   end
-    
-  #   if @user_seasonings.map(&:valid?).all?      
-  #     @user_seasonings.each do |us|
-  #       us.save
-  #     end
-  #     redirect_to action: :index
-  #   else
-  #     render :new
-  #   end
-  # end
-
   private
   
   def seasoning_params
-    params.require(:seasoning).permit(:name, :user_created_at, :created_at, :updated_at, :user_id, user_ids: [], :seasoning_id, seasoning_ids: [], seasonings: {}).merge(user_id: current_user.id)
+    params.require(:seasoning).permit(:name, :user_created_at, :created_at, :updated_at, :user_id, user_ids: [], seasoning_ids: [], seasonings: {}).merge(user_id: current_user.id)
   end
 
 end

--- a/app/models/seasoning.rb
+++ b/app/models/seasoning.rb
@@ -1,10 +1,7 @@
 class Seasoning < ApplicationRecord
-  has_and_belongs_to_many :users,
-    foreign_key: "user_id",
-    dependent: :destroy
-  
   # has_many :user_seasonings, foreign_key: "user_id", dependent: :destroy
   # has_many :users, through: :user_seasonings
+
   # accepts_nested_attributes_for :user_seasonings, allow_destroy: true
 
 

--- a/app/models/seasoning.rb
+++ b/app/models/seasoning.rb
@@ -1,5 +1,18 @@
 class Seasoning < ApplicationRecord
-  # has_many :user_seasonings, foreign_key: 'user_id', dependent: :destroy
+  # has_many :user_seasonings, foreign_key: "user_id", dependent: :destroy
   # has_many :users, through: :user_seasonings
+
+  # accepts_nested_attributes_for :user_seasonings, allow_destroy: true
+
+
+  #オブジェクト名.match(/正規表現/)
+#   def self.search(search)
+#     if search !=""
+#       Seasoning.match()
+#     else
+#       Seasoning.all
+#     end
+#   end
+
 end
 

--- a/app/models/seasoning.rb
+++ b/app/models/seasoning.rb
@@ -1,7 +1,10 @@
 class Seasoning < ApplicationRecord
+  has_and_belongs_to_many :users,
+    foreign_key: "user_id",
+    dependent: :destroy
+  
   # has_many :user_seasonings, foreign_key: "user_id", dependent: :destroy
   # has_many :users, through: :user_seasonings
-
   # accepts_nested_attributes_for :user_seasonings, allow_destroy: true
 
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,9 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   
   has_one_attached :image
-
+  has_and_belongs_to_many :seasonings,
+    foreign_key: "seasoning_id"
+  
   # has_many :user_seasonings, foreign_key: "seasoning_id"
   # has_many :seasonings, through: :user_seasonings
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
   
   has_one_attached :image
 
-  # has_many :user_seasonings, foreign_key: 'seasoning_id'
+  # has_many :user_seasonings, foreign_key: "seasoning_id"
   # has_many :seasonings, through: :user_seasonings
 
   # accepts_nested_attributes_for :user_seasonings, allow_destroy: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,9 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   
   has_one_attached :image
-  has_and_belongs_to_many :seasonings,
-    foreign_key: "seasoning_id"
-  
+
   # has_many :user_seasonings, foreign_key: "seasoning_id"
   # has_many :seasonings, through: :user_seasonings
 

--- a/app/models/user_seasoning.rb
+++ b/app/models/user_seasoning.rb
@@ -1,4 +1,4 @@
 class UserSeasoning < ApplicationRecord
-  # belongs_to :user, optional: true
-  # belongs_to :seasoning, optional: true
+  belongs_to :user #, optional: true
+  belongs_to :seasoning #, optional: true
 end

--- a/app/models/user_seasoning.rb
+++ b/app/models/user_seasoning.rb
@@ -1,4 +1,4 @@
 class UserSeasoning < ApplicationRecord
-  # belongs_to :user
-  # belongs_to :seasoning
+  # belongs_to :user, optional: true
+  # belongs_to :seasoning, optional: true
 end

--- a/app/models/user_seasoning.rb
+++ b/app/models/user_seasoning.rb
@@ -1,4 +1,4 @@
 class UserSeasoning < ApplicationRecord
-  belongs_to :user #, optional: true
-  belongs_to :seasoning #, optional: true
+  # belongs_to :user, optional: true
+  # belongs_to :seasoning, optional: true
 end

--- a/app/views/seasonings/index.html.erb
+++ b/app/views/seasonings/index.html.erb
@@ -9,7 +9,7 @@
       <%= form_with url:rakuten_search_path, method: :get, local: true do |f| %>
         <%= label_tag :recipe_category, 'キーワード検索', class: 'search-label'%>
         <%= f.text_field :recipe_category, class: 'serch-form', placeholder: "料理名や材料名を入力" %>
-        <%= submit_tag "検索", class: 'recipe-detail-btn'%>
+        <%= f.submit "検索", class: 'recipe-detail-btn'%>
       <% end %>
 
       <h3 class='lists-title'>ランキング１位 獲得の人気レシピ</h3>

--- a/app/views/seasonings/new.html.erb
+++ b/app/views/seasonings/new.html.erb
@@ -7,8 +7,8 @@
         <h3><%= link_to "uchino_aji", "/", class: 'main-subtitle' %></h3><br />
         <h2>うちの調味料登録</h2>
 
-        <%= form_with model: @seasoning, url: seasonings_path, method: :post, local: true do |f| %>          
-        <%#= form_with model: @seasoning, url: user_seasonings_path, method: :post, local: true do |f| %>          
+        <%= form_with model: @seasoning, url: seasonings_path(@user), method: :post, local: true do |f| %>          
+        <%#= form_with model: @seasoning, url: user_seasonings_path(@user), method: :post, local: true do |f| %>          
           <div class="form">
             <span class='optional'>(任意)</span>
           </div>

--- a/app/views/seasonings/new.html.erb
+++ b/app/views/seasonings/new.html.erb
@@ -12,11 +12,11 @@
           <div class="form">
             <span class='optional'>(任意)</span>
           </div>
-          <%= f.fields_for :user_seasonings do |fus| %>
-            <%= fus.label :name, "基本の調味料" %>
-            <%= fus.collection_check_boxes(:seasoning_ids, Seasoning.all, :id, :name) %>
-            <%= fus.label :name, "調味料項目を追加する" %><br/>
-            <%= fus.text_field :name, class: 'serch-form' %>
+          <%= f.fields_for :seasonings do |fs| %>
+            <%= fs.label :name, "基本の調味料" %>
+            <%= fs.collection_check_boxes(:seasoning_ids, Seasoning.all, :id, :name) %><br/>
+            <%= fs.label :name, "調味料項目を追加する" %>
+            <%= fs.text_field :name, class: 'serch-form' %>
           <% end %>
           <div class="actions">
             <%# binding.pry %>

--- a/app/views/seasonings/new.html.erb
+++ b/app/views/seasonings/new.html.erb
@@ -7,8 +7,8 @@
         <h3><%= link_to "uchino_aji", "/", class: 'main-subtitle' %></h3><br />
         <h2>うちの調味料登録</h2>
 
-        <%= form_with model: @seasoning, url: seasonings_path(@user), method: :post, local: true do |f| %>
-          
+        <%= form_with model: @seasoning, url: seasonings_path, method: :post, local: true do |f| %>          
+        <%#= form_with model: @seasoning, url: user_seasonings_path, method: :post, local: true do |f| %>          
           <div class="form">
             <span class='optional'>(任意)</span>
           </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -23,7 +23,7 @@
         <div class='user-seasonings'>
         </div>
         
-        <p><%= link_to "調味料を登録", new_seasoning_path, class: 'recipe-detail-btn' %></p>
+        <p><%= link_to "調味料を登録", new_user_seasoning_path, class: 'recipe-detail-btn' %></p>
 
       </div>
     </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -23,7 +23,7 @@
         <div class='user-seasonings'>
         </div>
         
-        <p><%= link_to "調味料を登録", new_user_seasoning_path, class: 'recipe-detail-btn' %></p>
+        <p><%= link_to "調味料を登録", new_seasoning_path, class: 'recipe-detail-btn' %></p>
 
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,22 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'seasonings#index'
   get 'rakuten_search' => 'seasonings#index'
-  resources :seasonings, only:[:index, :new, :create]
-  resources :users, only:[:show]
+
+  resources :users, :seasonings, only:[:index, :new, :create, :show] do
+    resources :user_seasonings
+  end
+
+  # resources :users, only:[:show]
+  # resources :seasonings, only:[:index, :new, :create] do
+  #   member do
+  #     get :users
+  #   end
+  # end
+
+  # resources :users do
+  #   resources :seasonings
+  # end
+
+
+  # resources :users, only:[:show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,11 +8,11 @@ Rails.application.routes.draw do
   # end
 
   # resources :users, only:[:show]
-  resources :seasonings, only:[:index, :new, :create] do
-    member do
-      get :users
-    end
-  end
+  # resources :seasonings, only:[:index, :new, :create] do
+  #   member do
+  #     get :users
+  #   end
+  # end
 
   # resources :users do
   #   resources :seasonings
@@ -24,5 +24,7 @@ Rails.application.routes.draw do
   #   end
   # end
 
-  # resources :users, only:[:show]
+  resources :seasonings, only:[:index, :new, :create]
+  resources :users, only:[:show]
+  
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,11 +8,11 @@ Rails.application.routes.draw do
   # end
 
   # resources :users, only:[:show]
-  # resources :seasonings, only:[:index, :new, :create] do
-  #   member do
-  #     get :users
-  #   end
-  # end
+  resources :seasonings, only:[:index, :new, :create] do
+    member do
+      get :users
+    end
+  end
 
   # resources :users do
   #   resources :seasonings
@@ -24,7 +24,5 @@ Rails.application.routes.draw do
   #   end
   # end
 
-  resources :seasonings, only:[:index, :new, :create]
-  resources :users, only:[:show]
-  
+  # resources :users, only:[:show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,21 +3,26 @@ Rails.application.routes.draw do
   root to: 'seasonings#index'
   get 'rakuten_search' => 'seasonings#index'
 
-  resources :users, :seasonings, only:[:index, :new, :create, :show] do
-    resources :user_seasonings
-  end
+  # resources :users, :seasonings, only:[:index, :new, :create, :show] do
+  #   resources :user_seasonings
+  # end
 
   # resources :users, only:[:show]
-  # resources :seasonings, only:[:index, :new, :create] do
-  #   member do
-  #     get :users
-  #   end
-  # end
+  resources :seasonings, only:[:index, :new, :create] do
+    member do
+      get :users
+    end
+  end
 
   # resources :users do
   #   resources :seasonings
   # end
 
+  # resources :users do
+  #   resources :seasonings do
+  #     resources :user_seasonings
+  #   end
+  # end
 
   # resources :users, only:[:show]
 end

--- a/db/migrate/20210108011227_rename_user_crated_at_column_to_seasonings.rb
+++ b/db/migrate/20210108011227_rename_user_crated_at_column_to_seasonings.rb
@@ -1,0 +1,5 @@
+class RenameUserCratedAtColumnToSeasonings < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :seasonings, :user_crated_at, :user_created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_19_123817) do
+ActiveRecord::Schema.define(version: 2021_01_08_011227) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 2020_12_19_123817) do
 
   create_table "seasonings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
-    t.datetime "user_crated_at"
+    t.datetime "user_created_at"
     t.datetime "created_at"
     t.datetime "updated_at"
   end


### PR DESCRIPTION
### 実現したいこと
調味料（seasoning）データ登録

### 発生しているエラー
<img width="1018" alt="スクリーンショット 2020-12-28 17 19 56" src="https://user-images.githubusercontent.com/72552210/103200541-f4d83500-4930-11eb-8daa-b1ac79f734dc.png">

### ターミナルログ
**[gist url](https://gist.github.com/bokko-chan/3f096aa1327680a6dfc47a2bf570f7c0)**

### 試したこと
- 読み込みし直すためmigration rollback,再migrationを実行
- migration カラム名に誤字がないか、schemaに中間テーブルのuser_idはあるか確認しました
- seasonings_controller.rb
  - newアクションに、中間テーブルuser_seasoningsをbuildしてuser_idを認識させようとしました
  - createアクションに、seasoningsにuser_seasoningsのuse_idを渡せるように
     インスタンス変数にuser情報を入れてbuildしたり、includesとwhereメソッドを使用してみました
  - parmitにuser_ids: [], user_id, user_seasonings_attributes: [seasoning_ids: []]を追記しました
- binding.pryからcurrent_user.idとSeasoningを結びつけて保存を試みたり、
   controllerの記述を入力してどこまで機能しているか確認しました（変数定義のメソッド記述は通っていても、create/build部分で同じエラーを出し続けてしまっています。
- modelにoptional: trueを追記しました

以上です。
上記controllerのnewアクションに中間テーブルをbuildすることと、
includes, whereを利用することはuser_idを認識させる手段として全くの見当違いでしょうか。
pry入力にメソッドは通っても、createでuse_idが無いと返されてしまう部分がよく理解できておりません。

解決できないのはbinding.pry後のログを読む力が不足しているためだと思います。
ログのポイントや検証のヒントをいただけましたら幸いです。

（前回のPR #17 に起きていたunparamited parameterエラーはseasonings: {}をparmitに追記して解決しました）

### 12/30 検証追記
ルーティングにネストを使用することで解消できなか確認中です。
- users,seasoningsにuser_seasoningsをネスト（member doも確認してみました）
  - エラーは解消できず、rails routesを見るとseasoningにuser_idを紐付けられていません
  - viewにcurrent_user.idの変数を渡す
- usersにseasoningsをネスト
  - 中間テーブルの親同士であるからかルーティングエラーになってしまいます

現時点で以上を確認し、保存時のエラーは変わらず発生する状態です。

### 補足情報
ruby '2.6.5'
rails '6.0.0'
mysql2 '0.5.3'
