### PR TITLE
1/11 build

### DIFF
--- a/app/controllers/seasonings_controller.rb
+++ b/app/controllers/seasonings_controller.rb
@@ -11,7 +11,7 @@ class SeasoningsController < ApplicationController
   end
 
   def create
-    binding.pry
+    # binding.pry
     # @user_seasonings = UserSeasoning.new
     # seasoning = Seasoning.create(seasoning_params)
     # @seasoning = @user_seasonings.build_seasoning(seasoning_params)
@@ -24,8 +24,14 @@ class SeasoningsController < ApplicationController
     
     # user_seasonings = UserSeasoning.new
     # @seasoning = Seasonig.new
-    @seasoning = Seasonig.find_or_created_by(seasoning_params)
-    @user_seasonings = @seasoning.user_seasonings.build({user_id: current_user.id}, {seasoning_id: @seasoning.id})
+    # @seasoning = Seasonig.find_or_created_by(seasoning_params)
+    @seasoning = Seasoning.find_or_create_by(name: seasoning_params[:seasonings][:name])
+    @user_seasonings = @seasoning.user_seasonings.build({user_id: current_user.id}, {seasoning_id: params[:seasoning_ids]})
+    @user_seasonings = user_seasonings.build({user_id: current_user.id}, {seasoning_id: params[:seasoning_ids]})
+    @user_seasonings = user_seasonings.build({user_id: current_user.id}, {seasoning_ids: params[:seasoning_ids]})
+    @user_seasonings = user_seasonings.build({user_id: current_user.id}, {seasoning_id: @seasoning.id})
+    # @user_seasonings = user_seasonings.build({user_id: current_user.id}, {seasoning_id: params[:seasoning_ids]}) << @seasoning
+    # @user_seasonings = @seasoning.user_seasonings.build({user_id: current_user.id}, {seasoning_id: @seasoning[:seasoning_ids]})
     # @user_seasonings = UserSeasoning.build({user_id: current_user.id}, {seasoning_id: @seasoning.id})
     
     if @user_seasonings.save
@@ -35,12 +41,9 @@ class SeasoningsController < ApplicationController
     end
   end
 
-
-
-
   #   @user_seasonings = [] 
   #   if seasoning_params[:seasonings][:name].present?
-  #     s = Seasoning.find_or_created_by(name: seasoning_params[:seasonings][:name])
+  #     s = Seasoning.find_or_create_by(name: seasoning_params[:seasonings][:name])
   #     @user_seasonings << UserSeasoning.new(seasoning_id: s.id, user_id: seasoning_params[:user_id])
   #   end
     


### PR DESCRIPTION
### 実現したいこと
調味料の登録をAssociation, ActiveRecordを利用してbuildメソッドで保存させること

### やるべきこと
- 登録画面から送信されたseasoning_paramsをSeasoning.find_or_create_by〜で生成し@seasoningに代入
- @seasoningのデータを用いてuser_seasoningsをbuildで生成し@user_seasoningsに代入
- @user_seasonings.saveで保存させる（ifで成功・失敗の条件分岐）

### やってみた結果
- @user_seasonings = @seasoning.user_seasonings.build({user_id: current_user.id}, {seasoning_id: params[:seasoning_ids]}) こちらだとuser_seasoningsにNomethodError、seasoning_idsもnilで返る
- @user_seasonings = user_seasonings.build({user_id: current_user.id}, {seasoning_id: @seasoning.id})　こちらだと属性値内は値が入って返る。buildに対してNomethodErrorになる。
build_user_seasonings〜の記述も試してみて、これはhas_and_belongs_to_manyでは使わない記法だとわかった。
@seasoning.idだけではなく、params内のseasoning_idsも取得して中間テーブルに入れなければならないことがわかった

### ターミナル コンソールログ
[gists](https://gist.github.com/bokko-chan/ea858eaeb8723ce90b3fddbc66b545dc)