### PR TITLE
newメソッド保存検証

### DIFF
--- a/app/controllers/seasonings_controller.rb
+++ b/app/controllers/seasonings_controller.rb
@@ -7,64 +7,72 @@ class SeasoningsController < ApplicationController
 
   def new
     @seasoning = Seasoning.new
-    # @user_seasoning = @seasoning.user_seasonings.build
   end
 
   def create
-    # binding.pry
-    # @user_seasonings = UserSeasoning.new
-    # seasoning = Seasoning.create(seasoning_params)
-    # @seasoning = @user_seasonings.build_seasoning(seasoning_params)
-    # @seasoning = @user_seasonings.seasonings.build(seasoning_params)
-    
-    # @user_seasonings = seasoning.user_seasonings.build(seasoning_params)
-    
+    # @user = User.new
     # @user = current_user
-    # @seasoning = @user.seasonings.build(seasoning_params)
-    
-    # user_seasonings = UserSeasoning.new
-    # @seasoning = Seasonig.new
-    # @seasoning = Seasonig.find_or_created_by(seasoning_params)
-    @seasoning = Seasoning.find_or_create_by(name: seasoning_params[:seasonings][:name])
-    @user_seasonings = @seasoning.user_seasonings.build({user_id: current_user.id}, {seasoning_id: params[:seasoning_ids]})
-    @user_seasonings = user_seasonings.build({user_id: current_user.id}, {seasoning_id: params[:seasoning_ids]})
-    @user_seasonings = user_seasonings.build({user_id: current_user.id}, {seasoning_ids: params[:seasoning_ids]})
-    @user_seasonings = user_seasonings.build({user_id: current_user.id}, {seasoning_id: @seasoning.id})
-    # @user_seasonings = user_seasonings.build({user_id: current_user.id}, {seasoning_id: params[:seasoning_ids]}) << @seasoning
-    # @user_seasonings = @seasoning.user_seasonings.build({user_id: current_user.id}, {seasoning_id: @seasoning[:seasoning_ids]})
-    # @user_seasonings = UserSeasoning.build({user_id: current_user.id}, {seasoning_id: @seasoning.id})
-    
-    if @user_seasonings.save
+    # @seasoning = Seasoning.new
+    # @user.seasonings << @seasoning
+
+    # @seasoning = Seasoning.new(seasoning_params)
+    # @seasoning = Seasoning.new(seasoning_id: seasoning_params[:seasonings][:seasoning_ids])
+    # @user.seasonings.ids << @seasoning
+
+
+    # @user.seasonings.ids
+    # @seasonings << Seasoning.new
+    # @seasoning = Seasoning.new(seasoning_params)
+    # @seasoning = Seasoning.new(seasoning_params[user_id:current_user.id])
+
+    @user = current_user
+    if seasoning_params[:seasonings][:name].present?
+      @seasoning = Seasoning.find_or_create_by(name: seasoning_params[:seasonings][:name])
+      @user.seasonings << @seasoning
+    else
+    end
+
+    seasonings_ary = seasoning_params[:seasonings][:seasoning_ids].compact
+    seasonings_ary.each do |sid|
+    # seasoning_params[:seasonings][:seasoning_ids].each do |sid|
+      @seasoning = Seasoning.new(id: sid)
+      # binding.pry
+      @user.seasonings << @seasoning
+    end
+
+    # binding.pry
+    if @user.seasonings.save
       redirect_to action: :index
     else
       render :new
     end
   end
 
+  #   ActiveRecord Associationを利用せず保存させる場合の記述
   #   @user_seasonings = [] 
   #   if seasoning_params[:seasonings][:name].present?
   #     s = Seasoning.find_or_create_by(name: seasoning_params[:seasonings][:name])
   #     @user_seasonings << UserSeasoning.new(seasoning_id: s.id, user_id: seasoning_params[:user_id])
   #   end
     
-  #   seasoning_params[:seasonings][:seasoning_ids].each do |sid|
-  #     @user_seasonings << UserSeasoning.new(seasoning_id: sid, user_id: seasoning_params[:user_id])
-  #   end
+    # seasoning_params[:seasonings][:seasoning_ids].each do |sid|
+    #   @user_seasonings << UserSeasoning.new(seasoning_id: sid, user_id: seasoning_params[:user_id])
+    # end
     
-  #   if @user_seasonings.map(&:valid?).all?      
-  #     @user_seasonings.each do |us|
-  #       us.save
-  #     end
-  #     redirect_to action: :index
-  #   else
-  #     render :new
-  #   end
+    # if @user_seasonings.map(&:valid?).all?      
+    #   @user_seasonings.each do |us|
+    #     us.save
+    #   end
+    #   redirect_to action: :index
+    # else
+    #   render :new
+    # end
   # end
 
   private
   
   def seasoning_params
-    params.require(:seasoning).permit(:name, :user_created_at, :created_at, :updated_at, :user_id, user_ids: [], :seasoning_id, seasoning_ids: [], seasonings: {}).merge(user_id: current_user.id)
+    params.require(:seasoning).permit(:name, :user_created_at, :created_at, :updated_at, seasoning_ids: [], seasonings: {}).merge(user_id: current_user.id)
   end
 
 end

--- a/app/models/seasoning.rb
+++ b/app/models/seasoning.rb
@@ -1,19 +1,24 @@
 class Seasoning < ApplicationRecord
-  has_and_belongs_to_many :users,
-    foreign_key: "user_id",
-    dependent: :destroy
-  
-  # has_many :user_seasonings, foreign_key: "user_id", dependent: :destroy
-  # has_many :users, through: :user_seasonings
+  # before_validation :delete_name_null
+
+  has_many :user_seasonings
+  has_many :users, through: :user_seasonings
   # accepts_nested_attributes_for :user_seasonings, allow_destroy: true
 
-
+  # validates :name, presence: true
   #オブジェクト名.match(/正規表現/)
 #   def self.search(search)
 #     if search !=""
 #       Seasoning.match()
 #     else
 #       Seasoning.all
+#     end
+#   end
+
+# private
+#   def delete_name_null
+#     # self.name = name.strip
+#     if seasoning.name = null
 #     end
 #   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,12 +5,8 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   
   has_one_attached :image
-  has_and_belongs_to_many :seasonings,
-    foreign_key: "seasoning_id"
-  
-  # has_many :user_seasonings, foreign_key: "seasoning_id"
-  # has_many :seasonings, through: :user_seasonings
-
+  has_many :user_seasonings
+  has_many :seasonings, through: :user_seasonings
   # accepts_nested_attributes_for :user_seasonings, allow_destroy: true
 
   with_options presence: true do

--- a/app/models/user_seasoning.rb
+++ b/app/models/user_seasoning.rb
@@ -1,4 +1,4 @@
 class UserSeasoning < ApplicationRecord
-  belongs_to :user #, optional: true
-  belongs_to :seasoning #, optional: true
+  belongs_to :user
+  belongs_to :seasoning
 end


### PR DESCRIPTION
### 実現したいこと
調味料の登録をAssociation, ActiveRecordを利用してnewメソッドで保存させること

### やるべきこと
```ruby
@user  =  current_user  
@seasoning  =  Seasoning . new   
@user . seasonings  <<  @seasoning 
@use.save
```
上記コードを元にエラー解消と保存機能実装を試みました。
- nameが空というエラーになるため、選択式のseasoning_idsと任意入力のnameをそれぞれ保存できるように記述してみたこと
- null制約を取るためにnull: trueにしてみたこと
- 空欄をバリデーション前に取り除くためbefore_validationメソッドを使ってみたこと
- seasoning_ids配列内のnilをcompactメソッドで取り除いてからなら保存できないか試してみたこと

### やってみた結果
- null制約を外したら「Mysql2::Error: Field 'name' doesn't have a default value」は出なくなり、nullでも保存できるようにはなった分、nameに入力せず保存したい場合大量にnullのレコードが生成され、ビューの選択肢にも空欄が発生してしまいました。（そのためnull: falseに戻しました）
- before_validation、compactメソッドを使用してみても同じmysqlエラーになります。
```ruby
    @user = current_user
    if seasoning_params[:seasonings][:name].present?
      @seasoning = Seasoning.find_or_create_by(name: seasoning_params[:seasonings][:name])
      @user.seasonings << @seasoning
    else
    end
```
この部分だけは任意の調味料名が入力されてる場合はseasoningとuser_seasoningsテーブル両方に保存されます。

### 次に試してみたいこと（質問）
- データベースにnullが入ってしまうのは避けたほうがよいと思い制約をかけ直したのですが、null制約を外してnullでも登録できるようにし、viewに空欄は表示させないコードを書いたほうがよろしいでしょうか。
- t.string  :name, null: false, default: ""として空白のデフォルト値を設定してからbefore_validation、compactメソッドを使用したほうがよかったでしょうか。（調べた上では関係ないと判断しまだデフォルト値は追加していません）
- コールバックでバリデーション前にnameカラムのnullを排除するという試みは今回のエラー対処としては間違っていますでしょうか。
- このエラーを調べているとmysql側の設定をnullでも通るように変更する記事が出てくるのですが、これはrails側でnull制約を外すのと同じことと判断し試しておりません。myspl側の設定は本件ではいじらないほうがよいでしょうか。

以上です。
よろしくお願い致します。